### PR TITLE
Update Homebrew installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ docki serve
 
 ### Homebrew
 
-> [!NOTE]
-> Installing it via homebrew will not include asciidoctor_revealjs. It can be installed afterwards with `docki install-reveal`
-
 ```shell
 brew tap quirinecker/homebrew-docki https://github.com/quirinecker/homebrew-docki
 ```


### PR DESCRIPTION
Removed note about Homebrew installation not including asciidoctor_revealjs.